### PR TITLE
In The Depths of the TreeSearch

### DIFF
--- a/src/bin/alphabeta_perf.rs
+++ b/src/bin/alphabeta_perf.rs
@@ -25,7 +25,7 @@ fn main() {
     let mut board = board::BoardState::new(board.clone());
     board.current_player = board::Color::Black;
 
-    let mut alphabeta_ai = ai::TreeSearchPlayer::new(5);
+    let mut alphabeta_ai = ai::TreeSearchPlayer::new(6);
     let start: board::BoardCoord;
     let end: board::BoardCoord;
     loop {

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -257,8 +257,10 @@ impl TitleScreen {
         if self.human_game.pressed(mouse_pos) {
             *screen_transition = ScreenTransition::StartGame(None, None);
         } else if self.ai_game.pressed(mouse_pos) {
-            *screen_transition =
-                ScreenTransition::StartGame(None, Some(Box::new(TreeSearchPlayer::new(6))));
+            *screen_transition = ScreenTransition::StartGame(
+                Some(Box::new(TreeSearchPlayer::new(6))),
+                Some(Box::new(TreeSearchPlayer::new(6))),
+            );
         }
 
         if self.quit_game.pressed(mouse_pos) {

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -258,7 +258,7 @@ impl TitleScreen {
             *screen_transition = ScreenTransition::StartGame(None, None);
         } else if self.ai_game.pressed(mouse_pos) {
             *screen_transition = ScreenTransition::StartGame(
-                Some(Box::new(TreeSearchPlayer::new(6))),
+                None, // Some(Box::new(TreeSearchPlayer::new(6))),
                 Some(Box::new(TreeSearchPlayer::new(6))),
             );
         }


### PR DESCRIPTION
**Relationships:** BoardState & better memory management

**Characters:** TreeSearch, BoardState, Killer Move, Principle Variation

**Additional Tags:** introspection, feelings jam, benchmark optimization, character study, 

-----

**Summary:** Ever since discovering that the Killer Move Heuristic was really just another aspect of themself, TreeSearch has gone on an introspective journey. Iteratively, TreeSearch dives deeper and deeper into their own mind to find the truth: That the Killer is no killer at all.

Oh also BoardState is there and they finally learn how to conserve memory properly.


-----

# Chapter 1

This PR implements iterative deepening for TreeSearch. This works by searching at lower max_depths and iteratively increasing it to the desired depth. It helps improve later searches by providing them with better initial move orderings.

This PR also fixes the fact that the killer move heuristic is actually just the principle variation being checked first. It also rips out the "second best move" stuff since that isn't needed for principle variation.

Lastly, this PR makes the insufficient material check much faster by avoiding a bunch of HashMap allocations.

Overall, this PR shaves off about a full second off of the alphabeta_perf benchmark.
