### PR TITLE
Selection V/H/Stackoverflow - A Layout Fic

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -330,6 +330,7 @@ impl<'a> HStack<'a> {
 /// A higher flex factor indicates that it should have more space, relative
 /// to other flex objects. This object does not have a bounding_box until
 /// `layout` is called
+#[derive(Debug, Clone)]
 pub struct FlexBox {
     pub bounding_box: Option<Rect>,
     pub flex_factor: f32,


### PR DESCRIPTION
**Relationships:** VStack/dyn Layout, HStack/dyn Layout

**Characters:** Selector, Layout, Generic Types, 

**Additional Tags:** types, more types, cascading changes, consequences, unsized, oc,

-----

**Summary:** All is well at Layout until a new type arrives--Selector! At first, they have trouble fitting within so many small and dynamic containers--after all, how is Selector supposed to fit themselves when they're already filled with so many Buttons? But despite that, Selector is key to changing everything about the Layout. Rumblings of mysterious and indescribable Generic Types are afoot, and Selector can blow this whole mystery right open.

-----

# Chapter 1

Implement a "radio button" style selector for the title screen so that players can select what AI to face off against. Doing this required rewriting VStack and HStack things to accept generic `Layout`able types. We also implement a couple of small macros to make it less verbose.