### PR TITLE
Chess: Reanimated!

### DIFF
--- a/src/ai.rs
+++ b/src/ai.rs
@@ -58,10 +58,7 @@ impl AIPlayer for MinOptPlayer {
         // opponent now has and track best move so far
         for (start, end) in my_moves {
             let mut board = board.clone();
-            board.take_turn(start, end).expect(&format!(
-                "Expected {:?} -> {:?} to be a legal move!",
-                start, end
-            ));
+            board.take_turn(start, end);
             let opponent_moves = board.board.get_all_moves(player.opposite());
             let score = opponent_moves.len();
 
@@ -230,16 +227,11 @@ impl TreeSearch {
         let mut i = 0;
         for (start, end) in moves {
             let mut next_position = position.clone();
-            next_position.take_turn(start, end).expect(&format!(
-                "Expected {:?} -> {:?} to be a legal move!",
-                start, end
-            ));
+            next_position.take_turn(start, end);
             // TODO: This really should get a real analysis, but for now, assuming the
             // player or ourself always promos to queen is an ok compromise.
             if let Some(coord) = next_position.need_promote() {
-                next_position
-                    .promote(coord, PieceType::Queen)
-                    .expect("Expected promotion to be legal!");
+                next_position.promote(coord, PieceType::Queen);
             }
 
             let (score, _, _, _) =

--- a/src/board.rs
+++ b/src/board.rs
@@ -1234,9 +1234,11 @@ pub enum BoardSide {
     Kingside,
 }
 
+// TODO: maybe unify this with the below MoveType enum. Kinda hacky
 pub enum MoveOrCastle {
     Move(BoardCoord, BoardCoord),
     Castle(BoardCoord, BoardCoord, BoardCoord, BoardCoord),
+    EnPassant(BoardCoord, BoardCoord, BoardCoord),
 }
 
 pub fn move_or_castle(board: &Board, start: BoardCoord, end: BoardCoord) -> MoveOrCastle {
@@ -1250,6 +1252,14 @@ pub fn move_or_castle(board: &Board, start: BoardCoord, end: BoardCoord) -> Move
             };
             MoveOrCastle::Castle(start, end, rook_start, rook_end)
         }
+        MoveType::EnPassant(side) => match side {
+            BoardSide::Queenside => {
+                MoveOrCastle::EnPassant(start, end, BoardCoord(start.0 - 1, start.1))
+            }
+            BoardSide::Kingside => {
+                MoveOrCastle::EnPassant(start, end, BoardCoord(start.0 + 1, start.1))
+            }
+        },
         _ => MoveOrCastle::Move(start, end),
     }
 }
@@ -1257,6 +1267,9 @@ pub fn move_or_castle(board: &Board, start: BoardCoord, end: BoardCoord) -> Move
 enum MoveType {
     Castle(Color, BoardSide),
     Normal,
+    // A "queenside" enpassant is defined as the attacking pawn moving towards the
+    // queen's side of the board (the x coordinate decreases), and vice versa for
+    // "kingside" enpassant
     EnPassant(BoardSide),
     Lunge,
 }

--- a/src/board.rs
+++ b/src/board.rs
@@ -42,32 +42,44 @@ impl BoardState {
         }
     }
 
-    /// Attempt to move the piece located at `start` to `end`. This function
-    /// returns `Ok()` if the move was successful and `Err` if it was not.
+    pub fn check_turn(&self, start: BoardCoord, end: BoardCoord) -> Result<(), &'static str> {
+        use MoveType::*;
+
+        if self.board.pawn_needs_promotion().is_some() {
+            return Err("A pawn needs to be promoted");
+        }
+
+        match move_type(&self.board, start, end) {
+            Castle(color, side) => self.board.can_castle(color, side),
+            Normal | Lunge => self.board.check_move(self.current_player, start, end),
+            EnPassant(side) => self.board.check_enpassant(self.current_player, start, side),
+        }
+    }
+
+    /// Move the piece located at `start` to `end`. This function panics if the
+    /// move would be illegal, so you should check the move first with `check_turn`
     /// It also sets `current_player` to the opposite color and handles the
     /// "just_lunged" pawn flags.
     /// A pawn needs promotion then this function always fails. You should
     /// call `promote` on the pawn.
     #[cfg_attr(feature = "perf", flame)]
-    pub fn take_turn(&mut self, start: BoardCoord, end: BoardCoord) -> Result<(), &'static str> {
+    pub fn take_turn(&mut self, start: BoardCoord, end: BoardCoord) {
         use Color::*;
         use MoveType::*;
 
-        debug_assert!(self.board.pawn_needs_promotion().is_none());
+        debug_assert!(self.check_turn(start, end).is_ok());
 
         #[cfg(feature = "perf")]
         let guard = fire::start_guard("move check + apply");
 
         match move_type(&self.board, start, end) {
             Castle(color, side) => {
-                self.board.can_castle(color, side)?;
                 // Clear the just lunged flags _after_ checking the move is valid
                 // That way, invalid moves don't try to clear the flag.
                 self.board.clear_just_lunged();
                 self.board.castle(color, side);
             }
             Normal => {
-                self.board.check_move(self.current_player, start, end)?;
                 self.board.clear_just_lunged();
                 if let Some(captured_piece) = self.get(end).0 {
                     match captured_piece.color {
@@ -78,17 +90,11 @@ impl BoardState {
                 self.board.move_piece(start, end)
             }
             Lunge => {
-                // A lunge is just a special case for a normal move, so we don't
-                // really do anything cool here
-                self.board.check_move(self.current_player, start, end)?;
                 // Clear the old lunge flag before the new one
                 self.board.clear_just_lunged();
                 self.board.lunge(start);
             }
             EnPassant(side) => {
-                self.board
-                    .check_enpassant(self.current_player, start, side)?;
-
                 if let Some(captured_piece) = self.get(end).0 {
                     match captured_piece.color {
                         Black => self.dead_black.push(captured_piece),
@@ -121,21 +127,28 @@ impl BoardState {
 
         #[cfg(feature = "perf")]
         flame::end("checkmate update");
-
-        Ok(())
     }
 
     pub fn need_promote(&self) -> Option<BoardCoord> {
         return self.board.pawn_needs_promotion();
     }
 
-    /// Attempt to promote the pawn.
-    pub fn promote(&mut self, coord: BoardCoord, piece: PieceType) -> Result<(), &'static str> {
+    /// Checks if the promotion is legal. This function returns Err if there is
+    /// no piece to promote to or if the promotion would be illegal.
+    pub fn check_promote(&self, coord: BoardCoord, piece: PieceType) -> Result<(), &'static str> {
+        // TODO: remove this if?
         if self.need_promote().is_none() {
             return Err("No pawn needs to be promoted at this time");
         }
 
-        self.board.check_promote(coord, piece)?;
+        self.board.check_promote(coord, piece)
+    }
+
+    /// Promotes the pawn. This function panics if the promotion is illegal. This
+    /// function also handles updating the checkmate state and current player
+    pub fn promote(&mut self, coord: BoardCoord, piece: PieceType) {
+        debug_assert!(self.check_promote(coord, piece).is_ok());
+
         self.board.promote_pawn(coord, piece);
 
         use Color::*;
@@ -146,7 +159,6 @@ impl BoardState {
 
         // Update the checkmate status
         self.checkmate = self.board.checkmate_state(self.current_player);
-        Ok(())
     }
 
     /// Return the list of valid moves for current player at the coordinate
@@ -1220,6 +1232,26 @@ impl fmt::Display for MoveList {
 pub enum BoardSide {
     Queenside,
     Kingside,
+}
+
+pub enum MoveOrCastle {
+    Move(BoardCoord, BoardCoord),
+    Castle(BoardCoord, BoardCoord, BoardCoord, BoardCoord),
+}
+
+pub fn move_or_castle(board: &Board, start: BoardCoord, end: BoardCoord) -> MoveOrCastle {
+    match move_type(board, start, end) {
+        MoveType::Castle(color, board_side) => {
+            let (rook_start, rook_end) = match (color, board_side) {
+                (Color::White, BoardSide::Queenside) => (BoardCoord(0, 0), BoardCoord(3, 0)),
+                (Color::White, BoardSide::Kingside) => (BoardCoord(7, 0), BoardCoord(5, 0)),
+                (Color::Black, BoardSide::Queenside) => (BoardCoord(0, 7), BoardCoord(3, 7)),
+                (Color::Black, BoardSide::Kingside) => (BoardCoord(7, 7), BoardCoord(5, 7)),
+            };
+            MoveOrCastle::Castle(start, end, rook_start, rook_end)
+        }
+        _ => MoveOrCastle::Move(start, end),
+    }
 }
 
 enum MoveType {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,4 @@
-mod ai;
-mod board;
-mod layout;
-mod rect;
-mod screen;
+use chess::screen;
 
 use ggez::conf;
 use ggez::event;

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -701,6 +701,10 @@ impl Grid {
                 animated_board.move_piece(start, end);
                 animated_board.move_piece(rook_start, rook_end);
             }
+            MoveOrCastle::EnPassant(start, end, remove) => {
+                animated_board.move_piece(start, end);
+                animated_board.remove(remove);
+            }
         }
         board.take_turn(start, end);
     }
@@ -988,10 +992,11 @@ impl AnimatedBoard {
         Ok(())
     }
 
+    fn remove(&mut self, coord: BoardCoord) {
+        self.pieces.remove(&coord);
+    }
+
     fn move_piece(&mut self, start: BoardCoord, end: BoardCoord) {
-        // TODO: This will not work for castling. You need to update the key of the rook
-        // as well as the king when you do a castle.
-        // ALSO TODO: THis will also not work for pawn promo
         let mut piece = self.pieces.remove(&start).unwrap();
         piece.set_target(self.to_screen_coord(end));
         self.pieces.insert(end, piece);

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -348,19 +348,36 @@ pub enum ScreenState {
 
 #[derive(Debug)]
 pub struct Grid {
+    // Size of a single square, in pixels
     square_size: f32,
+    // Offset of the entire screen from the upper left.
+    // TODO: this can probably be removed.
     offset: na::Vector2<f32>,
+    // The list of locations the currently held piece can be placed. If this
+    // vector is empty, then either no piece is being held or there are no places
+    // to move that piece
     drop_locations: Vec<BoardCoord>,
     board: BoardState,
+    // TODO: maybe make most of this UI stuff into its own struct?
+    // The checkerboard background of the board
     background_mesh: graphics::Mesh,
+    // Restart and main menu buttons
     restart: Button,
     main_menu: Button,
+    // Promotion buttons. Note that this is reused for both white's and black's side
+    // and we just move the buttons around as needed. The PieceType tells what
+    // piece the pawn will promote to.
     promote_buttons: Vec<(Button, PieceType)>,
+    // Displays who's turn it is and if there is check/checkmate/etc or not
     status: TextBox,
+    // Lists the dead piece for each player.
     dead_black: TextBox,
     dead_white: TextBox,
+    // If this is None, then use a human player. Otherwise, use the listed AI player
     ai_black: Option<Box<dyn AIPlayer>>,
     ai_white: Option<Box<dyn AIPlayer>>,
+    // If Some, then this will contain the previous move just made. This is used
+    // to highlight the "just moved" piece.
     last_move: Option<(BoardCoord, BoardCoord)>,
 }
 


### PR DESCRIPTION
**Relationships:** Grid ♠️ GridUI ♠️ Sidebar 

**Characters:** Grid, GridUI (oc), AnimatedBoard (oc), AnimatedPiece (oc), Sidebar (oc)

**Additional Tags:** original characters, reanimated, multi-animator-project, alternate universe, cartoon AU

-----

**Summary:** It's here, the Chess Reanimation Project featuring over `[REDACTED]` artists is finally complete! Chess, finally reimagined in a cartoony, animated style! Reexperience Chess like never before--in full 60fps motion!

-----

# Chapter 1

This PR adds a bunch of stuff, actually.

The largest change is introducing animated pieces to the game. Now, when a piece is moved, it will animate to the spot its supposed to go to. This makes for a much nicer gameplay experience as pieces no longer teleport to the end spot. We achieve this via an `AnimatedBoard`, which holds `AnimatedPieces`. The board is similar to `Board` or `BoardState` in that it keeps a representation of the board in memory, and should be updated accordingly as the actual underlying board is updated. AnimatedPiece targets are set appropriately as needed.

This PR also adds a "last piece moved" indicator by highlighting the squares that a piece just moved from and to.

Lastly, we do some restructuring of `Grid` and split it into `Sidebar` and `GridUI`. Sidebar handles the UI stuff on the sidebar (restart buttons, promotion buttons, dead piece indicator, etc) while `GridUI` handles drawing the checkerboard grid, pieces, square highlights, and so on. This was done to make `Grid` somewhat less massive in complexity.